### PR TITLE
fix typo using RIGHT DOUBLE QUOTATION MARK instead of {"}

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Each single timer can then be verified if its duration was within a given range 
 ```robotframework
 *** Settings ***
 Library         Timer
+Suite Teardown    Verify Benchmark
 Test Setup      Benchmark Setup
 Test Teardown   Benchmark TearDown
 
@@ -25,7 +26,7 @@ Benchmark Setup
   Start Timer   ${TEST NAME}
 Benchmark TearDown
   Stop Timer    ${TEST NAME}
-  Timer Results Within    3 seconds   0 seconds   ${TEST NAME}
+  Verify Single Timer    3 seconds   0 seconds   ${TEST NAME}
 
 *** Test Cases ***
 Example No 1 Passes
@@ -36,6 +37,9 @@ Example No 2 Passes
 
 Example No 3 Will Fail
   Sleep   3 second
+
+Verify Benchmark
+  Verify All Timers   fail_on_errors=False
 ```
 
 

--- a/src/Timer/__init__.py
+++ b/src/Timer/__init__.py
@@ -35,7 +35,7 @@ def assert_string(benchmark_name, difference, lower_than, higher_than):
     difference = secs_to_timestr(ms_to_s(difference))
     lower_than = secs_to_timestr(ms_to_s(lower_than))
     higher_than = secs_to_timestr(ms_to_s(higher_than))
-    return 'Difference ({}) in ”{}" is not in between {} and {}'.format(difference, benchmark_name, lower_than, higher_than)
+    return 'Difference ({}) in "{}" is not in between {} and {}'.format(difference, benchmark_name, lower_than, higher_than)
 
 
 class Timer(DynamicCore):


### PR DESCRIPTION
In __init__.py fix typo using RIGHT DOUBLE QUOTATION MARK instead of '''"'''